### PR TITLE
Fix: Handle missing `min_row` and `max_row` in `rel_rows`

### DIFF
--- a/src/img2table/tables/processing/borderless_tables/__init__.py
+++ b/src/img2table/tables/processing/borderless_tables/__init__.py
@@ -45,7 +45,7 @@ def coherent_table(tb: Table, elements: List[Cell]) -> Optional[Table]:
                 .to_dicts()
                 )
 
-    if len(rel_rows) > 0:
+    if len(rel_rows) > 0 and rel_rows[0].get("min_row") is not None and rel_rows[0].get("max_row") is not None:
         # Get new rows
         new_rows = tb.items[rel_rows[0].get("min_row"):rel_rows[0].get("max_row") + 1]
         if len(new_rows) >= 2:


### PR DESCRIPTION
- Added checks to ensure `min_row` and `max_row` are not `None` before slicing `tb.items`.
- Prevents potential error when `max_row` is `None` and arithmetic is attempted.