### PR TITLE
Added find_packages in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     setup_requires=['pbr'],
+    packages=find_packages(where="src"),
     package_dir={'': 'src'},
     pbr=True,
 )


### PR DESCRIPTION
Fixed pip install not getting all files from git repo by adding `packages=find_packages(where="src")` to setup.py.